### PR TITLE
fix: remove conditional hooks and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ return (
 ### Popover.Content or Tooltip.Content
 
 - Pass the popover content as children here.
+- Accepts [accessibilityLabel](https://necolas.github.io/react-native-web/docs/accessibility/) prop. This will be announced by the screenreader when popup opens.
 
 ### Popover.Arrow or Tooltip.Arrow
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm i react-native-popper
 ## Import
 
 ```js
-import { Popover, Tooltip } from 'react-native-popper'
+import { Popover, Tooltip } from 'react-native-popper';
 ```
 
 ## Usage
@@ -77,7 +77,7 @@ Tooltip:
 Popover:
 
 ```jsx
-const [isOpen, setIsOpen] = React.useState(false)
+const [isOpen, setIsOpen] = React.useState(false);
 
 return (
   <Popover
@@ -95,13 +95,13 @@ return (
       <Text>Hello World</Text>
     </Popover.Content>
   </Popover>
-)
+);
 ```
 
 Tooltip:
 
 ```jsx
-const [isOpen, setIsOpen] = React.useState(false)
+const [isOpen, setIsOpen] = React.useState(false);
 
 return (
   <Tooltip
@@ -118,7 +118,7 @@ return (
       <Text>Hello World</Text>
     </Tooltip.Content>
   </Tooltip>
-)
+);
 ```
 
 ## API
@@ -126,7 +126,7 @@ return (
 ### Popover or Tooltip
 
 | Prop                                 | Type                          | Default                                  | Description                                                                                                                                                                  |
-| ------------------------------------ | ----------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------------------ | ----------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
 | trigger (Required)                   | React Element or Ref          | -                                        | Element or ref which will be used as a Trigger                                                                                                                               |
 | on                                   | "press", "longpress", "hover" | "press" for Popover "hover for Tooltips" | The action type which should trigger the Popover                                                                                                                             |
 | isOpen                               | boolean                       | false                                    | Useful for controlled popovers                                                                                                                                               |
@@ -134,7 +134,7 @@ return (
 | defaultIsOpen                        | boolean                       | false                                    | Specifies initial visibility of popover                                                                                                                                      |
 | placement                            | string                        | bottom                                   | "top", "bottom", "left", "right", "top left", "top right", "left top", "left bottom", "right top", "right bottom", "bottom left", "bottom right"                             |
 | shouldOverlapWithTrigger             | boolean                       | false                                    | Whether the popover should overlap with trigger                                                                                                                              |
-| placement                            | string                        | bottom                                   | "top", "bottom", "left", "right", "top left", "top right", "left top", "left bottom", "right top", "right bottom", "bottom left", "bottom right"                             |  |
+| placement                            | string                        | bottom                                   | "top", "bottom", "left", "right", "top left", "top right", "left top", "left bottom", "right top", "right bottom", "bottom left", "bottom right"                             |     |
 | offset                               | number                        | 0                                        | Distance between popover and trigger's main axis                                                                                                                             |
 | animated                             | boolean                       | true                                     | Determines whether the content should animate                                                                                                                                |
 | animationEntryDuration               | number                        | 150                                      | Duration of entry animation                                                                                                                                                  |
@@ -168,7 +168,7 @@ return (
 | style    | ViewStyle | No       | -       | Style will be passed to the View which is used as Arrow        |
 | children | ReactNode | No       | -       | Supply custom Arrow. Make sure the arrow is pointing upward. ▲ |
 
-### OverlayProvider
+### <a name="overlayprovider"/> OverlayProvider
 
 - When using mode="multiple" or Tooltip, we use custom Portal to prevent shifting accessibility focus when opened.
   To use this Portal, we need to wrap the app with OverlayProvider.
@@ -184,7 +184,17 @@ function App() {
 
 Phew, That's it!
 
-## Why Popover and Tooltip separate component?
+## Why not always use a custom Portal instead of RN's built in Modal?
+
+- RN's built in Modal shifts accessibility focus to the first element when it opens. This is hard to achieve using a custom Portal.
+- Tooltips don't need to shift accessibility focus.
+- Thus,
+- On Web, we use ReactDOM's Portal in all cases.
+- On Android/iOS,
+  - For Popovers, defaults to RN modal (can be overriden via `mode` prop. Needs [OverlayProvider](#overlayprovider)).
+  - For Tooltips, defaults to custom Portal (Needs [OverlayProvider](#overlayprovider))
+
+## Why are Popover and Tooltip separate components?
 
 **Reason**: Different Accessibility requirements.
 
@@ -214,7 +224,7 @@ yarn android
 - Mode prop accepts `single` and `multiple` values. Defaults to `single`.
 - When set to `single`, it uses RN's built-in Modal which shifts accessibility focus to the first element when opened.
 - RN's built in modal doesn't support multiple popups at once unless they are nested. If you need multiple popup support without nesting use mode="multiple".
-- To use mode="multiple", wrap the entire app with OverlayProvider which enables custom Portal like functionality.
+- To use mode="multiple", wrap the entire app with [OverlayProvider](#overlayprovider) which enables custom Portal like functionality.
 - I am still figuring out if we can make this simple.
 
 ## Limitations

--- a/example/src/examples/MultiplePopovers.tsx
+++ b/example/src/examples/MultiplePopovers.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, Pressable, Text, View } from 'react-native';
-import { Tooltip } from 'react-native-popper';
+import { Popover } from 'react-native-popper';
 
 export default function App() {
   const [visible, setVisible] = React.useState(true);
@@ -53,7 +53,8 @@ export default function App() {
 
       {['top', 'left', 'right', 'bottom'].map((p) => {
         return (
-          <Tooltip
+          <Popover
+            mode="multiple"
             isOpen={visible}
             trigger={trigger}
             key={p}
@@ -61,19 +62,20 @@ export default function App() {
             //@ts-ignore
             placement={p}
           >
-            <Tooltip.Content>
-              <Tooltip.Arrow />
-              <View style={styles.Tooltip}>
+            <Popover.Content>
+              <Popover.Arrow />
+              <View style={styles.Popover}>
                 <Text>{p}</Text>
               </View>
-            </Tooltip.Content>
-          </Tooltip>
+            </Popover.Content>
+          </Popover>
         );
       })}
 
       {['top right', 'bottom right'].map((p) => {
         return (
-          <Tooltip
+          <Popover
+            mode="multiple"
             isOpen={visible}
             trigger={trigger3}
             key={p}
@@ -81,19 +83,20 @@ export default function App() {
             //@ts-ignore
             placement={p}
           >
-            <Tooltip.Content>
-              <Tooltip.Arrow />
-              <View style={styles.Tooltip}>
+            <Popover.Content>
+              <Popover.Arrow />
+              <View style={styles.Popover}>
                 <Text>{p}</Text>
               </View>
-            </Tooltip.Content>
-          </Tooltip>
+            </Popover.Content>
+          </Popover>
         );
       })}
       {['right bottom', 'left bottom'].map((p) => {
         return (
           visible && (
-            <Tooltip
+            <Popover
+              mode="multiple"
               isOpen={visible}
               trigger={trigger4}
               key={p}
@@ -101,20 +104,21 @@ export default function App() {
               //@ts-ignore
               placement={p}
             >
-              <Tooltip.Content>
-                <Tooltip.Arrow />
-                <View style={styles.Tooltip}>
+              <Popover.Content>
+                <Popover.Arrow />
+                <View style={styles.Popover}>
                   <Text>{p}</Text>
                 </View>
-              </Tooltip.Content>
-            </Tooltip>
+              </Popover.Content>
+            </Popover>
           )
         );
       })}
 
       {['right top', 'left top'].map((p) => {
         return (
-          <Tooltip
+          <Popover
+            mode="multiple"
             isOpen={visible}
             trigger={trigger5}
             key={p}
@@ -122,19 +126,20 @@ export default function App() {
             //@ts-ignore
             placement={p}
           >
-            <Tooltip.Content>
-              <Tooltip.Arrow />
-              <View style={styles.Tooltip}>
+            <Popover.Content>
+              <Popover.Arrow />
+              <View style={styles.Popover}>
                 <Text>{p}</Text>
               </View>
-            </Tooltip.Content>
-          </Tooltip>
+            </Popover.Content>
+          </Popover>
         );
       })}
 
       {['top left', 'bottom left'].map((p) => {
         return (
-          <Tooltip
+          <Popover
+            mode="multiple"
             isOpen={visible}
             trigger={trigger2}
             key={p}
@@ -142,19 +147,20 @@ export default function App() {
             //@ts-ignore
             placement={p}
           >
-            <Tooltip.Content>
-              <Tooltip.Arrow />
-              <View style={styles.Tooltip}>
+            <Popover.Content>
+              <Popover.Arrow />
+              <View style={styles.Popover}>
                 <Text>{p}</Text>
               </View>
-            </Tooltip.Content>
-          </Tooltip>
+            </Popover.Content>
+          </Popover>
         );
       })}
 
       {['Top - overlap with trigger'].map((p) => {
         return (
-          <Tooltip
+          <Popover
+            mode="multiple"
             trigger={trigger6}
             key={p}
             onOpenChange={toggleVisible}
@@ -162,12 +168,12 @@ export default function App() {
             isOpen={visible}
             shouldOverlapWithTrigger
           >
-            <Tooltip.Content>
-              <View style={styles.Tooltip}>
+            <Popover.Content>
+              <View style={styles.Popover}>
                 <Text>{p}</Text>
               </View>
-            </Tooltip.Content>
-          </Tooltip>
+            </Popover.Content>
+          </Popover>
         );
       })}
     </>
@@ -180,7 +186,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  Tooltip: {
+  Popover: {
     padding: 10,
     borderWidth: 2,
     borderColor: 'blue',

--- a/example/src/examples/PopoverExample.tsx
+++ b/example/src/examples/PopoverExample.tsx
@@ -12,7 +12,7 @@ export default function App() {
         }
       >
         <Popover.Backdrop />
-        <Popover.Content>
+        <Popover.Content accessibilityLabel="this should be the label of this popover">
           <Popover.Arrow color="#D1D5DB"></Popover.Arrow>
           <View style={styles.popover}>
             <Text>Hello from popover</Text>

--- a/example/src/examples/TooltipExample.tsx
+++ b/example/src/examples/TooltipExample.tsx
@@ -14,6 +14,7 @@ export default function App() {
             </Pressable>
           }
         >
+          <Tooltip.Backdrop />
           <Tooltip.Content>
             <View style={styles.tooltip}>
               <Text style={styles.tooltipText}>Hello world </Text>

--- a/example/src/examples/TooltipExample.tsx
+++ b/example/src/examples/TooltipExample.tsx
@@ -14,7 +14,6 @@ export default function App() {
             </Pressable>
           }
         >
-          <Tooltip.Backdrop />
           <Tooltip.Content>
             <View style={styles.tooltip}>
               <Text style={styles.tooltipText}>Hello world </Text>

--- a/example/src/examples/TriggerRefExample.tsx
+++ b/example/src/examples/TriggerRefExample.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { StyleSheet, Pressable, Text, View } from 'react-native';
+import { Popover } from 'react-native-popper';
+export default function App() {
+  const triggerRef = React.useRef(null);
+  const [isOpen, setIsOpen] = React.useState(false);
+  return (
+    <View style={styles.wrapper}>
+      <Pressable ref={triggerRef} onPress={() => setIsOpen(!isOpen)}>
+        <Text>Press me</Text>
+      </Pressable>
+      <Popover trigger={triggerRef} isOpen={isOpen} onOpenChange={setIsOpen}>
+        <Popover.Backdrop />
+        <Popover.Content>
+          <Popover.Arrow color="#D1D5DB"></Popover.Arrow>
+          <View style={styles.popover}>
+            <Text>Hello from popover</Text>
+            <Pressable>
+              <Text>Hello</Text>
+            </Pressable>
+          </View>
+        </Popover.Content>
+      </Popover>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  popover: {
+    padding: 10,
+    borderWidth: 2,
+    borderColor: 'blue',
+  },
+});

--- a/example/src/examples/index.ts
+++ b/example/src/examples/index.ts
@@ -1,7 +1,7 @@
-export { default as TriggerRefExample } from './TriggerRefExample';
 export { default as PopoverExample } from './PopoverExample';
 export { default as TooltipExample } from './TooltipExample';
 export { default as IOSPopoverExample } from './iOSPopoverExample';
 export { default as EntryExitAnimation } from './ComplexExample';
 export { default as MultiplePopovers } from './MultiplePopovers';
+export { default as TriggerRefExample } from './TriggerRefExample';
 export { default as CustomSVGArrow } from './ArrowExample';

--- a/example/src/examples/index.ts
+++ b/example/src/examples/index.ts
@@ -1,6 +1,7 @@
+export { default as TriggerRefExample } from './TriggerRefExample';
 export { default as PopoverExample } from './PopoverExample';
 export { default as TooltipExample } from './TooltipExample';
 export { default as IOSPopoverExample } from './iOSPopoverExample';
 export { default as EntryExitAnimation } from './ComplexExample';
-export { default as MultipleTooltips } from './MultipleTooltips';
+export { default as MultiplePopovers } from './MultiplePopovers';
 export { default as CustomSVGArrow } from './ArrowExample';

--- a/src/Overlay/Overlay.tsx
+++ b/src/Overlay/Overlay.tsx
@@ -13,6 +13,7 @@ export function Overlay(props: IOverlayProps) {
     onClose,
     focusable = true,
     animated = true,
+    mode = 'single',
     animationEntryDuration,
     animationExitDuration,
   } = props;
@@ -29,33 +30,34 @@ export function Overlay(props: IOverlayProps) {
   }
 
   // If focusable we render it in RN modal so it shifts accessibility focus
-  const content = focusable ? (
-    <Modal visible={true} transparent>
-      <Animated.View
-        style={[StyleSheet.absoluteFill, styles]}
-        pointerEvents="box-none"
-      >
-        <OverlayContext.Provider value={{ onClose }}>
-          {children}
-        </OverlayContext.Provider>
-      </Animated.View>
-    </Modal>
-  ) : (
-    <OverlayContainer>
-      <Animated.View
-        style={[
-          StyleSheet.absoluteFill,
-          styles,
-          { marginTop: StatusBar.currentHeight },
-        ]}
-        pointerEvents="box-none"
-      >
-        <OverlayContext.Provider value={{ onClose }}>
-          {children}
-        </OverlayContext.Provider>
-      </Animated.View>
-    </OverlayContainer>
-  );
+  const content =
+    focusable && mode === 'single' ? (
+      <Modal visible={true} transparent>
+        <Animated.View
+          style={[StyleSheet.absoluteFill, styles]}
+          pointerEvents="box-none"
+        >
+          <OverlayContext.Provider value={{ onClose }}>
+            {children}
+          </OverlayContext.Provider>
+        </Animated.View>
+      </Modal>
+    ) : (
+      <OverlayContainer>
+        <Animated.View
+          style={[
+            StyleSheet.absoluteFill,
+            styles,
+            { marginTop: StatusBar.currentHeight },
+          ]}
+          pointerEvents="box-none"
+        >
+          <OverlayContext.Provider value={{ onClose }}>
+            {children}
+          </OverlayContext.Provider>
+        </Animated.View>
+      </OverlayContainer>
+    );
 
   return content;
 }

--- a/src/Overlay/Overlay.web.tsx
+++ b/src/Overlay/Overlay.web.tsx
@@ -19,6 +19,7 @@ export function Overlay(props: IOverlayProps): any {
     shouldCloseOnOutsideClick = true,
     focusable = true,
     animated = true,
+    mode = 'single',
     animationEntryDuration,
     animationExitDuration,
     overlayRef,
@@ -53,7 +54,7 @@ export function Overlay(props: IOverlayProps): any {
         style={[StyleSheet.absoluteFill, styles]}
         pointerEvents="box-none"
       >
-        {focusable ? (
+        {focusable && mode === 'single' ? (
           <FocusScope
             contain={trapFocus}
             autoFocus={autoFocus}

--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -23,36 +23,40 @@ const Popover = (props: IPopoverProps) => {
     setIsOpen(false);
   };
 
-  let triggerElem = null;
+  const isTriggerElement = React.isValidElement(props.trigger);
+  const isTriggerRef = props.trigger.hasOwnProperty('current');
 
-  // Received a trigger ref
-  if (props.trigger.hasOwnProperty('current')) {
-    // @ts-ignore
-    triggerRef = props.trigger;
-  }
-  // Received a trigger element
-  else if (React.isValidElement(props.trigger)) {
-    const triggerExistingProps = props.trigger.props;
-    // Trigger won't be changes in rerenders, so this seems safe
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const handlers = useOn({
-      on: props.on,
-      onClose: handleClose,
-      onOpen: handleOpen,
-      overlayRef,
-      ...triggerExistingProps,
-    });
-
-    triggerElem = React.cloneElement(props.trigger, {
-      ref: triggerRef,
-      ...handlers,
-    });
-  } else {
+  if (!isTriggerElement && !isTriggerRef) {
     console.warn(
       `Popover: Invalid 'trigger' prop received, please pass a valid ReactElement or a Ref`
     );
   }
 
+  // @ts-ignore - We already checked isValidElement above.
+  const triggerExistingProps = isTriggerElement ? props.trigger.props : {};
+
+  const handlers = useOn({
+    on: props.on,
+    onClose: handleClose,
+    onOpen: handleOpen,
+    overlayRef,
+    ...triggerExistingProps,
+  });
+
+  let triggerElem = null;
+
+  if (isTriggerRef) {
+    // @ts-ignore
+    triggerRef = props.trigger;
+  } else if (isTriggerElement) {
+    // @ts-ignore - We already checked isValidElement above.
+    triggerElem = React.cloneElement(props.trigger, {
+      ref: triggerRef,
+      ...handlers,
+    });
+  }
+
+  // ARIA props
   const { triggerProps, contentProps } = usePopover({ isOpen });
 
   if (triggerElem) {
@@ -71,6 +75,7 @@ const Popover = (props: IPopoverProps) => {
         isKeyboardDismissable={props.isKeyboardDismissable}
         focusable={props.focusable ?? isFocusabe}
         animated={props.animated}
+        mode={props.mode}
         animationEntryDuration={props.animationEntryDuration}
         animationExitDuration={props.animationExitDuration}
         overlayRef={overlayRef}

--- a/src/Popper/Popper.tsx
+++ b/src/Popper/Popper.tsx
@@ -6,6 +6,7 @@ import type {
   IScrollContentStyle,
   IArrowStyles,
   IPopoverArrowProps,
+  IPopoverContent,
 } from '../types';
 import { createContext } from '../utils';
 
@@ -34,7 +35,7 @@ const Popper = (
   return <PopperProvider {...props}>{props.children}</PopperProvider>;
 };
 
-const PopperContent = ({ children }: { children: any }) => {
+const PopperContent = ({ children, accessibilityLabel }: IPopoverContent) => {
   const {
     triggerRef,
     shouldFlip,
@@ -133,6 +134,7 @@ const PopperContent = ({ children }: { children: any }) => {
       ref={overlayRef}
       collapsable={false}
       style={overlayStyle.overlay}
+      accessibilityLabel={accessibilityLabel}
       {...contentProps}
     >
       {arrowElement}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -160,7 +160,10 @@ type IOnProps = {
 export const useOn = (props: IOnProps) => {
   let { on = 'press', onOpen } = props;
 
-  let events = useHoverInteraction(props, { enabled: on === 'hover' });
+  let events = useHoverInteraction(props, {
+    enabled: on === 'hover' && isPlatformWeb,
+  });
+
   if (events) {
     return events;
   }
@@ -188,15 +191,9 @@ const useHoverInteraction = (
   props: IOnProps,
   { enabled }: { enabled: boolean }
 ) => {
-  // Platform won't change in between, so breaking the conditional hook rule won't be an issue
-  /* eslint-disable react-hooks/rules-of-hooks */
-  if (!isPlatformWeb) {
-    return;
-  }
-
   const { overlayRef, onOpen, onClose } = props;
-  const { isHovered: isOverlayHovered } = useHover(overlayRef);
-  const { isFocused: isOverlayFocused } = useFocus(overlayRef);
+  const { isHovered: isOverlayHovered } = useHover(overlayRef, { enabled });
+  const { isFocused: isOverlayFocused } = useFocus(overlayRef, { enabled });
   const [isTriggerHovered, setIsTriggerHovered] = React.useState(false);
   const [isTriggerFocused, setIsTriggerFocused] = React.useState(false);
 
@@ -258,9 +255,10 @@ const useHoverInteraction = (
   /* eslint-enable react-hooks/rules-of-hooks */
 };
 
-const useHover = (targetRef: any) => {
+const useHover = (targetRef: any, { enabled }: { enabled: boolean }) => {
   const [isHovered, setIsHovered] = React.useState(false);
   React.useEffect(() => {
+    if (!enabled) return;
     if (targetRef && targetRef.current) {
       targetRef.current.onmouseover = () => {
         setIsHovered(true);
@@ -269,14 +267,15 @@ const useHover = (targetRef: any) => {
         setIsHovered(false);
       };
     }
-  }, [targetRef]);
+  }, [targetRef, enabled]);
 
   return { isHovered };
 };
 
-const useFocus = (targetRef: any) => {
+const useFocus = (targetRef: any, { enabled }: { enabled: boolean }) => {
   const [isFocused, setIsFocused] = React.useState(false);
   React.useEffect(() => {
+    if (!enabled) return;
     let focusInistener = () => {
       setIsFocused(true);
     };
@@ -297,7 +296,7 @@ const useFocus = (targetRef: any) => {
         currentTarget.removeEventListener('focusout', focusOutListener);
       }
     };
-  }, [targetRef]);
+  }, [targetRef, enabled]);
 
   return { isFocused };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export type OverlayType = 'single' | 'multiple';
 
 export type IPopoverProps = {
   focusable?: boolean;
-  // mode?: OverlayType;
+  mode?: OverlayType;
   defaultIsOpen?: boolean;
   on?: 'press' | 'longPress' | 'hover';
   isOpen?: boolean;
@@ -86,6 +86,7 @@ export type IScrollContentStyle = {
 };
 
 export type IOverlayProps = {
+  mode?: OverlayType;
   focusable?: boolean;
   isOpen: boolean;
   children: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export type IPopoverContentImpl = {
 
 export type IPopoverContent = {
   children: React.ReactNode;
+  accessibilityLabel?: string;
 };
 
 export type IArrowStyles = {


### PR DESCRIPTION
This PR,

- Resolves - https://github.com/intergalacticspacehighway/react-native-popper/issues/2
- Fixes `mode` prop.
- Defaults Tooltip `on` to `hover` on the web and `press` on other platforms.
- Improves Readme.
- Adds accessibilityLabel prop on PopoverContent.