### PR TITLE
fix: register document event handlers in capture phase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-popper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Headless popovers",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -397,12 +397,13 @@ export const useCloseOnOutsideClick = ({
       if (!clickedInRefs) onClose();
     };
     if (isPlatformWeb) {
-      document.addEventListener('click', listener);
+      // Register at capture phase as Touchable prevents event bubbling.
+      document.addEventListener('click', listener, true);
     }
 
     return () => {
       if (isPlatformWeb) {
-        document.removeEventListener('click', listener);
+        document.removeEventListener('click', listener, true);
       }
     };
   }, [refs, onClose, enabled]);


### PR DESCRIPTION
Fixes - https://github.com/intergalacticspacehighway/react-native-popper/issues/12

## Issue
The above issue occurs as Pressable prevents event bubbling and `shouldCloseOnOutsideClick` attaches click listener that is listening for bubble events.

## Fix
Adds document listener on capture phase instead of bubble phase.